### PR TITLE
added iroh-ssh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Projects & resources building with iroh!
 - [Dumbpipe](https://github.com/n0-computer/dumbpipe) - Cross-device unix pipe.
 - [malai](https://malai.sh) - Share your dev server (and more) over P2P.
 - [Stash](https://github.com/gertjanvanzwieten/stash) - A pickle alternative that stores objects in a central database.
-- [do-ssh](https://github.com/doEggi/do-ssh) - Tunnels a ssh-connection over iroh.
+- [do-ssh](https://github.com/doEggi/do-ssh) - Tunnels an ssh-connection over iroh.
 - [iroh-ssh](https://github.com/rustonbsd/iroh-ssh) - SSH to any machine without ip.
 
 ## Collaboration

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,8 @@ Projects & resources building with iroh!
 - [Dumbpipe](https://github.com/n0-computer/dumbpipe) - Cross-device unix pipe.
 - [malai](https://malai.sh) - Share your dev server (and more) over P2P.
 - [Stash](https://github.com/gertjanvanzwieten/stash) - A pickle alternative that stores objects in a central database.
-- [do-ssh](https://github.com/doEggi/do-ssh) - Tunnes an ssh-connection over iroh.
+- [do-ssh](https://github.com/doEggi/do-ssh) - Tunnels a ssh-connection over iroh.
+- [iroh-ssh](https://github.com/rustonbsd/iroh-ssh) - SSH to any machine without ip.
 
 ## Collaboration
 


### PR DESCRIPTION
added iroh-ssh (https://github.com/rustonbsd/iroh-ssh) and fixed typo in do-ssh Tunnes to Tunnels (the original readme of do-ssh says "Tunnels")