### PR TITLE
Add Dropwire to File Sharing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,7 @@ Projects & resources building with iroh!
 - [ARK Drop Desktop](https://github.com/ARK-Builders/ARK-Drop-Desktop) - Use QR codes to quickly send and receive files between devices.
 - [Alt-sendme](https://github.com/tonyantony300/alt-sendme) - A cross-platform desktop application for file sharing, built with Tauri.
 - [DataBeam](https://github.com/vinay-winai/DataBeam) - File sharing desktop app with features like: share via short custom code or QR code, share text, auto-retry on failure, and automatic overwrite conflict resolution.
+- [Dropwire](https://github.com/muhamadjawdatsalemalakoum/dropwire) - Send any file directly between devices, end-to-end encrypted and resumable, with no account and no server.
 - [iroh_send](https://github.com/thiswillbeyourgithub/iroh-send) - Send files or directories by sharing an env variable (python).
 - [lis](https://github.com/riffcc/lis) - Life is short, but data should live forever.
 - [Quicksend](https://github.com/israelyago/QuickSend) - Send files peer to peer.


### PR DESCRIPTION
Adds **Dropwire** to the **File Sharing** section.

Dropwire is a free, open-source desktop app for peer-to-peer file transfer, built entirely on iroh + iroh-blobs. Send any file directly between devices — end-to-end encrypted (QUIC/TLS 1.3), resumable, with no account and no server in the middle. Cross-platform (Windows/macOS/Linux), dual-licensed MIT/Apache-2.0.

- Repo: https://github.com/muhamadjawdatsalemalakoum/dropwire
- Site: https://muhamadjawdatsalemalakoum.github.io/dropwire/

Entry inserted in lexicographic order (after DataBeam, before iroh_send) and follows the required `- [name](link) - Description.` format. Thanks for maintaining the list! 🙏
