### PR TITLE
docs: add Kith to Tools for Thought

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@ Projects & resources building with iroh!
 
 ## Tools for Thought
 
+- [Kith](https://github.com/muhamadjawdatsalemalakoum/kith) - Serverless, no-account, end-to-end-encrypted sync for your own devices — memory, tabs, and files — that your AI can also read and write over MCP.
 - [Obsiroh](https://github.com/DrHongos/obsiroh) - An Obsidian sync method with iroh.
 
 ## Web3


### PR DESCRIPTION
Adds **Kith** to *Tools for Thought*.

Kith is a serverless, no-account, end-to-end-encrypted desktop app (Windows/macOS/Linux; Rust + Tauri) that keeps your memory, tabs, and files in sync across your own devices — directly over iroh (QUIC) + Automerge CRDTs, with no cloud and no server that can read your data. It's MCP-native, so a local AI assistant (Claude Desktop, Cursor) reads and writes the same local data.

Free and open source (MIT/Apache-2.0).

- Repo: https://github.com/muhamadjawdatsalemalakoum/kith
- Entry inserted in lexicographic order (before Obsiroh) and follows the contributing format (capitalized, period-terminated, https link).
